### PR TITLE
fix: change xpath

### DIFF
--- a/googlepatentscraper/document.py
+++ b/googlepatentscraper/document.py
@@ -59,7 +59,7 @@ class Document():
             list: List containing dictionaries with attributes cpc, first_code
         """
         cpcs = []
-        for element in self.__get(doc, "//li[@itemprop='cpcs']", many=True):
+        for element in self.__get(doc, "//li[@itemprop='classifications']", many=True):
             cpc = {}
             cpc['first_code'] = True if \
                 self.__get(element, ".//meta[@itemprop='FirstCode']/@content") == "true" else False

--- a/googlepatentscraper/document.py
+++ b/googlepatentscraper/document.py
@@ -115,7 +115,11 @@ class Document():
             for claim in self.__get(claim_section, ".//div[@itemprop='content'][1]/*[contains(@class, 'claims')]/*[contains(@class, 'claim')]", many=True):
                 claim_obj = {}
                 claim_obj['dependent'] = True if claim.get('class') == "claim-dependent" else False
-                claim_obj['number'] = int(self.__get(claim, "./div[contains(@class,'claim')][1]/@num"))
+                claim_num = self.__get(claim, "./div[contains(@class,'claim')][1]/@num")
+                if claim_num.isdecimal():
+                    claim_obj['number'] = int(claim_num)
+                else:
+                    continue
                 text = "".join(claim.xpath("./descendant::*/text()"))
                 claim_obj['text'] = text.strip() if text else None
                 claims.append(claim_obj)


### PR DESCRIPTION
1. Change itemprop from `'cpcs'` to `'classification'` in the `__get_cpcs` function.
2. In the `__get_claims` function, add a conditional statement to check whether the string `self.__get(claim, "./div[contains(@class,'claim')][1]/@num")` is a valid number, in order to prevent a ValueError from occurring.